### PR TITLE
Add podcast S03E03: Container Security Runtime with Alex Zenla

### DIFF
--- a/content/podcast/S03E03.md
+++ b/content/podcast/S03E03.md
@@ -1,0 +1,31 @@
+---
+title: "Container Security Runtime: Rethinking Isolation with Alex Zenla"
+date: "2026-05-05T00:00:00+00:00"
+duration: 79
+season: 3
+episode: 3
+guests:
+  - Alex Zenla
+description: |
+    Containers were never designed to be a security boundary, yet we have spent the last decade treating them like one. I'm joined by Alex Zenla, Founder and CTO of Edera, to explore how that assumption shaped modern systems and why it is starting to break under real-world pressure.
+youtube: "https://www.youtube.com/watch?v=hGHY_cRZ8Hs"
+spotify: "https://open.spotify.com/episode/18nY07q8mo874CrX6eYaL4?si=bBlSwjJEQrSEQ7LezLkMDQ"
+apple: ""
+amazon: ""
+aliases:
+  - /podcast/S03E03/
+---
+
+Containers were never designed to be a security boundary, yet we have spent the last decade treating them like one. I'm joined by Alex Zenla, Founder and CTO of Edera, to explore how that assumption shaped modern systems and why it is starting to break under real-world pressure. From insecure IoT deployments to container-heavy production stacks, Alex brings a perspective grounded in building and breaking systems at scale, and what it actually takes to rethink isolation from first principles.
+
+Alex's background starts early, contributing to open source projects and working deeply in the world of IoT, one of the most notoriously insecure domains in tech. Working with industrial systems exposed a harsh reality: outdated software, fragile networking assumptions, and environments where security was an afterthought. These experiences, particularly at Google, led him to question whether the underlying infrastructure we rely on can ever be made secure without fundamentally changing how workloads are isolated.
+
+That question ultimately led to Edera. What began as an attempt to secure constrained IoT devices evolved into a broader realization that containers are the wrong abstraction for strong isolation. Alex and his team explored alternatives, moving away from namespace-based models toward hypervisor-driven approaches that create real boundaries between workloads. Along the way, they faced trade-offs around performance, compatibility, and developer experience, especially in ecosystems like Kubernetes where expectations are deeply ingrained.
+
+We dig into what it means to build a container security runtime that treats isolation as a first-class concern rather than an afterthought. This means rethinking everything from how virtual machines are provisioned to how file systems, volume mounts, and networking are handled. Alex walks through the nuances of kernel-level risks, the limitations of existing tools like gVisor and Kata, and why seemingly simple features like volume mounts introduce significant attack surfaces. The result is a system that blends virtualization and container workflows in a way that feels familiar to developers but operates with a fundamentally different security model.
+
+We also explore the broader industry dynamics that got us here. Developer experience drove the adoption of containers, but often at the cost of security guarantees. Compliance frameworks can reinforce outdated practices instead of encouraging better ones. And as AI agents introduce highly autonomous, non-deterministic workloads, the need for secure, ephemeral, and reversible environments becomes even more urgent. Alex's thinking points toward a shift in how we approach compute itself, moving from static systems to ones that can safely execute, roll back, and adapt in real time.
+
+For builders and security-minded engineers, this episode reframes container isolation as something that needs to be redesigned from the ground up, not patched on top of an abstraction that was never built for it.
+
+## Links


### PR DESCRIPTION
## Summary
- Add new podcast episode S03E03 featuring Alex Zenla (Founder/CTO of Edera) on container security runtime and rethinking workload isolation
- Includes YouTube and Spotify links; Apple and Amazon links still pending

## Test plan
- [ ] Verify episode renders correctly on `/podcast/s03e03/`
- [ ] Confirm alias `/podcast/S03E03/` redirects properly
- [ ] Check podcast listing page includes the new episode

🤖 Generated with [Claude Code](https://claude.com/claude-code)