### PR TITLE
Add RedMonk press coverage

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -28,6 +28,10 @@
       publication: InfoQ
       title: "QCon London 2026: SBOMs Move from Best Practice to Legal Obligation as CRA Enforcement Looms"
       link: https://www.infoq.com/news/2026/03/sbom-viktor-petersson/
+    - type: press
+      publication: RedMonk
+      title: "AI Slop & the Vulnerability Treadmill"
+      link: https://redmonk.com/kholterhoff/2026/05/05/ai-slop-vulnerability-treadmill/
     - type: panel
       event: Digital Signage Summit Europe
       location: Munich, Germany


### PR DESCRIPTION
## Summary
- Add RedMonk article "AI Slop & the Vulnerability Treadmill" by Kate Holterhoff to the 2026 press section
- Article quotes Viktor on Screenly's vulnerability reporting program and the economics of AI-generated bug reports

## Test plan
- [ ] Verify `hugo serve` renders the new press entry on the about/events page
- [ ] Confirm link resolves to the correct RedMonk article

🤖 Generated with [Claude Code](https://claude.com/claude-code)