### PR TITLE
Add proxmox-imgctl follow-up post and projects page entries

### DIFF
--- a/content/blog/2026-05-14-proxmox-imgctl.md
+++ b/content/blog/2026-05-14-proxmox-imgctl.md
@@ -1,0 +1,111 @@
+---
+slug: proxmox-imgctl
+title: "proxmox-imgctl: A Single Rust Binary for Proxmox Cloud Image Templates"
+date: '2026-05-14T10:00:00Z'
+tags:
+- proxmox
+- rust
+- self-hosted
+- virtualization
+- infrastructure
+- cloud-init
+---
+
+A few weeks ago I [wrote up](/2026/04/23/ubuntu-cloud-images-on-proxmox/) the bash scripts I use to turn Ubuntu cloud images into Proxmox templates and clone them into VMs. The scripts work, but every time I went to spin something up I found myself re-reading the post to remember which env vars to set, which storage pool I'd picked, and which snippet file was the current "good" one. The scripts were a recipe, not a tool.
+
+So I built the tool. [`proxmox-imgctl`](https://github.com/vpetersson/proxmox-imgctl) is a single Rust binary you drop on a Proxmox node. Run it, answer a handful of menu prompts, and you get a verified cloud image template or a fresh VM clone, with cloud-init wired up, secure boot enabled, and the right disk layout. No script collection, no Python runtime, no Ansible playbook. Just a binary.
+
+It's what I've been using myself for the last few weeks. The bash scripts in the previous post are retired.
+
+## What it does
+
+Two top-level actions:
+
+- **Build template from cloud image.** Pick a distro from a curated catalog (Ubuntu 26.04 / 24.04 / 22.04, Debian 13 / 12 / 11), pick a storage pool and a VMID, confirm. The binary downloads the image, verifies it against the upstream `SHA256SUMS` / `SHA512SUMS`, creates the VM shell with OVMF + secure boot + cloud-init drive + virtio, imports the disk, and marks it as a template.
+- **Spawn VM from template.** Pick a template, pick a cloud-init profile (`minimal`, `dev`, `docker`, an interactive generator, or any existing snippet on disk), answer prompts for username and `ssh_import_id`, and the binary clones, resizes, attaches the snippet, and starts the VM.
+
+Each step that mutates state shows a plan and asks for confirmation before executing. There's a `--dry-run` flag that prints every `qm` command, snippet write, and download it would do, without touching anything. Useful for previewing on a non-root account or even off the Proxmox node entirely.
+
+## Why a single Rust binary
+
+Cluttering up `/usr/local/bin` with three bash scripts, a checksum file, and a snippets directory was the worst part of the old workflow. Cluttering it with a Python tool plus `requirements.txt` plus a virtualenv would have been worse. So:
+
+- **Single static binary.** `x86_64-linux-musl`, no glibc dependency, no runtime. The same binary runs on PVE 8 (Debian 12, glibc 2.36) and PVE 9 (Debian 13, glibc 2.41) without a rebuild. Drop it in `/usr/local/bin/proxmox-imgctl`, done.
+- **Rust.** Cheap to ship, fast to start, strict about errors. The downloader, the SHA256/SHA512 verifier, and the interactive prompts are all in the same binary with no shelling out except to `qm`, `pvesm`, and `pvesh`: the three Proxmox CLIs I genuinely need.
+- **No new abstractions over Proxmox.** The tool shells out to `qm` rather than talking to the HTTP API, because (a) it's designed to run on the node anyway and (b) `qm disk import` has no clean API equivalent. The wrapper layer is thin and easy to swap if I ever want to make it run remotely.
+
+It also gracefully handles the [`qm importdisk` -> `qm disk import` rename](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_8.0) that landed in PVE 8: it tries the modern form first and falls back to the legacy name only if the CLI rejects the syntax. One binary, both PVE majors.
+
+## Install
+
+A static musl binary is attached to every tagged release. On the Proxmox node, as root:
+
+```bash
+curl -fsSLO https://github.com/vpetersson/proxmox-imgctl/releases/latest/download/proxmox-imgctl-x86_64-linux
+curl -fsSLO https://github.com/vpetersson/proxmox-imgctl/releases/latest/download/proxmox-imgctl-x86_64-linux.sha256
+sha256sum -c proxmox-imgctl-x86_64-linux.sha256
+install -m 0755 proxmox-imgctl-x86_64-linux /usr/local/bin/proxmox-imgctl
+```
+
+First run as root seeds `/etc/proxmox-imgctl.toml` with sensible defaults (`storage`, `snippet_storage`, `snippet_dir`, `bridge`, `cache_dir`) and exits so you can review them.
+
+## Building a template
+
+```text
+$ sudo proxmox-imgctl
+? What do you want to do?  Build template from cloud image
+? Base image:  Ubuntu 24.04 (noble)
+✓ Cached image at /var/lib/proxmox-imgctl/cache/ubuntu-24.04-noble.img matches checksum.
+? Storage pool:  local-lvm
+? Network bridge: vmbr0
+? Template VMID: 9000
+? Template name: ubuntu-noble-template
+? Memory (e.g. 1024M, 2G): 1G
+? CPU sockets: 1
+? Cores per socket: 1
+
+Plan:
+  base image:  https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img -> /var/lib/proxmox-imgctl/cache/ubuntu-24.04-noble.img
+  vmid:        9000
+  name:        ubuntu-noble-template
+  storage:     local-lvm
+  bridge:      vmbr0
+  resources:   1 socket(s) × 1 core(s) = 1 vCPU, 1G memory
+
+? Proceed? Yes
+-> Creating VM shell...
+-> Importing disk (this can take a minute)...
+-> Attaching disk, configuring boot, adding cloud-init drive, marking as template...
+
+✓ Template 9000 (ubuntu-noble-template) ready.
+```
+
+Spawning a VM from that template is the same shape: pick a template, pick a profile (`minimal`, `dev`, `docker`, or your own), confirm. The `dev` profile, for what it's worth, is what I use for the agent-sandbox VMs I described in the last post: a single user, passwordless sudo, SSH keys imported from GitHub, plus `git`, `build-essential`, `curl`, `vim`, `htop`, `tmux`, `jq`. The `docker` profile adds the official `get.docker.com` installer on top.
+
+## Image catalog
+
+| Distro | Release   | Codename |
+| ------ | --------- | -------- |
+| Ubuntu | 26.04 LTS | resolute |
+| Ubuntu | 24.04 LTS | noble    |
+| Ubuntu | 22.04 LTS | jammy    |
+| Debian | 13        | trixie   |
+| Debian | 12        | bookworm |
+| Debian | 11        | bullseye |
+
+Each entry resolves through the upstream `current` / `latest` symlink, so a fresh download always grabs the latest point release.
+
+## Known limitations
+
+- **amd64 only.** No arm64 release builds yet. The code is portable; I just don't have an arm64 PVE node to validate against.
+- **Hardcoded catalog.** Adding a distro means appending an entry to `src/catalog.rs` and rebuilding. Good enough for now. I'd rather pin the checksum logic per distro than have a free-form config.
+- **Single-node mindset.** The tool doesn't yet help you target a specific node on a cluster.
+- **No delete / edit actions.** Build template and spawn VM are the only two top-level actions; cleanup is `qm destroy` and `qm stop` directly, the way you'd do it anyway.
+
+## Where it goes next
+
+The bash-script version of the workflow lived in my head and in a blog post. This one lives in a binary I can hand to someone else, with a release pipeline, CI that runs `fmt --check`, `clippy -D warnings`, and a build/test pass on every PR. That makes the OpenTofu / declarative version I gestured at in the last post a much smaller jump: the catalog, the profiles, and the `qm` invocations are all already factored into modules. Wiring them up behind a Terraform provider, or just behind a non-interactive CLI mode, is the obvious next step.
+
+In the meantime: if you're managing Proxmox cloud images and the scripts in the last post felt like the right idea but the wrong ergonomics, give the binary a spin.
+
+[github.com/vpetersson/proxmox-imgctl](https://github.com/vpetersson/proxmox-imgctl)

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -14,12 +14,12 @@
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
       <!-- sbomify -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 relative" data-github-repo="sbomify/sbomify">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="sbomify/sbomify">
         <h2 class="text-xl font-bold mb-3 font-body">sbomify</h2>
         <p class="text-base mb-4 leading-relaxed">
           Your security artifact hub. Generate, manage, and share SBOMs and compliance documents with stakeholders. Available as self-hosted or cloud service.
         </p>
-        <a href="https://sbomify.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm block mb-3">
+        <a href="https://sbomify.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm block mb-3 mt-auto">
           Visit site <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
         </a>
         <a href="https://github.com/sbomify/sbomify/stargazers" target="_blank" rel="noopener noreferrer" class="github-stars" style="display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: #9ca3af; text-decoration: none; opacity: 0.7;">
@@ -30,34 +30,34 @@
       </div>
 
       <!-- Screenly -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col">
         <h2 class="text-xl font-bold mb-3 font-body">Screenly</h2>
         <p class="text-base mb-4 leading-relaxed">
           The secure digital signage company.
         </p>
-        <a href="https://screenly.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
+        <a href="https://screenly.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm mt-auto">
           Visit site <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
         </a>
       </div>
 
       <!-- Viktopia Studio -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col">
         <h2 class="text-xl font-bold mb-3 font-body">Viktopia Studio</h2>
         <p class="text-base mb-4 leading-relaxed">
           Home for open source projects that graduate from experiments to sustainable ventures.
         </p>
-        <a href="https://studio.viktopia.io" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
+        <a href="https://studio.viktopia.io" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm mt-auto">
           Visit site <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
         </a>
       </div>
 
       <!-- DSLF -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 relative" data-github-repo="vpetersson/dslf">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="vpetersson/dslf">
         <h2 class="text-xl font-bold mb-3 font-body">DSLF</h2>
         <p class="text-base mb-4 leading-relaxed">
           Damn Small Link Forwarder - A blazing fast, self-hosted link shortener and LinkTree alternative written in Rust.
         </p>
-        <div>
+        <div class="mt-auto">
           <div class="flex flex-col gap-2 mb-3">
             <a href="https://301.vpetersson.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
               <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg> View demo <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
@@ -78,12 +78,12 @@
       </div>
 
       <!-- Podcast RSS Generator -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 relative" data-github-repo="vpetersson/podcast-rss-generator">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="vpetersson/podcast-rss-generator">
         <h2 class="text-xl font-bold mb-3 font-body">Podcast RSS Generator</h2>
         <p class="text-base mb-4 leading-relaxed">
           A CI-friendly podcast RSS generator designed to run in GitHub Actions. Most podcast hosting tools are just thin wrappers around S3 storage - this cuts out the middleman and generates your feed directly in CI. Powers <a href="/podcast" class="text-blue-400 hover:text-blue-300 underline">Nerding Out with Viktor</a>.
         </p>
-        <a href="https://github.com/vpetersson/podcast-rss-generator" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm block mb-3">
+        <a href="https://github.com/vpetersson/podcast-rss-generator" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm block mb-3 mt-auto">
           <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23.96-.27 1.98-.4 3-.4s2.04.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.7.82.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg> View on GitHub <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
         </a>
         <a href="https://github.com/vpetersson/podcast-rss-generator/stargazers" target="_blank" rel="noopener noreferrer" class="github-stars" style="display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: #9ca3af; text-decoration: none; opacity: 0.7;">
@@ -94,12 +94,12 @@
       </div>
 
       <!-- Notipus -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 relative" data-github-repo="notipus/Notipus">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="notipus/Notipus">
         <h2 class="text-xl font-bold mb-3 font-body">Notipus</h2>
         <p class="text-base mb-4 leading-relaxed">
           Payment notifications for Slack. Get enriched alerts from Stripe, Shopify, and Maxio with customer context, churn risk scores, and LTV data.
         </p>
-        <div>
+        <div class="mt-auto">
           <div class="flex flex-col gap-2 mb-3">
             <a href="https://notipus.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
               Visit site <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
@@ -117,12 +117,12 @@
       </div>
 
       <!-- IP Geolocation -->
-      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 relative" data-github-repo="vpetersson/ipgeolocation">
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="vpetersson/ipgeolocation">
         <h2 class="text-xl font-bold mb-3 font-body">IP Geolocation</h2>
         <p class="text-base mb-4 leading-relaxed">
           Self-hosted IP geolocation API built in Rust. A drop-in replacement for commercial services, providing sub-millisecond response times with zero external dependencies.
         </p>
-        <div>
+        <div class="mt-auto">
           <div class="flex flex-col gap-2 mb-3">
             <a href="https://geoip.vpetersson.com" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
               <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg> View demo <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
@@ -135,6 +135,52 @@
             </a>
           </div>
           <a href="https://github.com/vpetersson/ipgeolocation/stargazers" target="_blank" rel="noopener noreferrer" class="github-stars" style="display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: #9ca3af; text-decoration: none; opacity: 0.7;">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23.96-.27 1.98-.4 3-.4s2.04.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.7.82.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg>
+            <span class="star-count">...</span>
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+          </a>
+        </div>
+      </div>
+
+      <!-- proxmox-imgctl -->
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="vpetersson/proxmox-imgctl">
+        <h2 class="text-xl font-bold mb-3 font-body">proxmox-imgctl</h2>
+        <p class="text-base mb-4 leading-relaxed">
+          Interactive cloud-image template and VM bootstrapper for Proxmox VE. A single Rust binary that builds checksum-verified Ubuntu and Debian templates and clones them into cloud-init-configured VMs.
+        </p>
+        <div class="mt-auto">
+          <div class="flex flex-col gap-2 mb-3">
+            <a href="https://github.com/vpetersson/proxmox-imgctl" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
+              <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23.96-.27 1.98-.4 3-.4s2.04.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.7.82.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg> View on GitHub <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+            </a>
+            <a href="/2026/05/14/proxmox-imgctl" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
+              <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg> Read the blog post
+            </a>
+          </div>
+          <a href="https://github.com/vpetersson/proxmox-imgctl/stargazers" target="_blank" rel="noopener noreferrer" class="github-stars" style="display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: #9ca3af; text-decoration: none; opacity: 0.7;">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23.96-.27 1.98-.4 3-.4s2.04.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.7.82.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg>
+            <span class="star-count">...</span>
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+          </a>
+        </div>
+      </div>
+
+      <!-- Jeha -->
+      <div class="bg-primaryBG rounded-lg p-6 hover:shadow-lg transition-shadow duration-200 flex flex-col relative" data-github-repo="vpetersson/jeha">
+        <h2 class="text-xl font-bold mb-3 font-body">Jeha</h2>
+        <p class="text-base mb-4 leading-relaxed">
+          Just Enough Home Automation. An opinionated, batteries-included Rust daemon for Zigbee2MQTT that does lighting (circadian rhythms, motion-activated lights, scenes) and nothing else.
+        </p>
+        <div class="mt-auto">
+          <div class="flex flex-col gap-2 mb-3">
+            <a href="https://github.com/vpetersson/jeha" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
+              <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23.96-.27 1.98-.4 3-.4s2.04.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.7.82.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg> View on GitHub <svg class="inline-block w-3 h-3 ml-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+            </a>
+            <a href="/2025/06/07/home-assistant-revamp/" class="text-blue-400 hover:text-blue-300 transition-colors text-sm">
+              <svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg> Read the blog post
+            </a>
+          </div>
+          <a href="https://github.com/vpetersson/jeha/stargazers" target="_blank" rel="noopener noreferrer" class="github-stars" style="display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: #9ca3af; text-decoration: none; opacity: 0.7;">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.39.6.11.82-.26.82-.58v-2.03c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.85 1.24 1.85 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23.96-.27 1.98-.4 3-.4s2.04.14 3 .4c2.28-1.55 3.29-1.23 3.29-1.23.66 1.66.24 2.88.12 3.18.77.84 1.24 1.91 1.24 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.21.7.82.58C20.56 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg>
             <span class="star-count">...</span>
             <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>


### PR DESCRIPTION
## Summary

- New blog post `content/blog/2026-05-14-proxmox-imgctl.md` — follow-up to the [April 23 Ubuntu cloud images on Proxmox post](https://vpetersson.com/2026/04/23/ubuntu-cloud-images-on-proxmox/). Introduces [`proxmox-imgctl`](https://github.com/vpetersson/proxmox-imgctl), a single static Rust binary that replaces the bash scripts from that post. Covers what it does, why a single Rust binary, install steps, a sample session, the Ubuntu/Debian catalog, and known limitations.
- `/projects` page: adds two new cards (`proxmox-imgctl` linking to the new post and GitHub; `Jeha` linking to the home-assistant-revamp post and GitHub).
- `/projects` page consistency: each card is now `flex flex-col` with `mt-auto` on the footer block, so the GitHub-stars pill (or the last link, for cards without one) is pinned to the bottom and cards in the same row line up visually regardless of description length.

## Test plan

- [x] `bun run lint` passes (markdown, scss, typecheck)
- [x] `hugo --minify` builds clean (955 pages)
- [x] New post renders at `/2026/05/14/proxmox-imgctl/`
- [x] `/projects` page renders with new cards and aligned footers
- [x] All external URLs in the post return 200 (GitHub, cloud-images.ubuntu.com, pve.proxmox.com)
- [x] Internal links to `/2026/04/23/ubuntu-cloud-images-on-proxmox/` and `/2025/06/07/home-assistant-revamp/` resolve
- [ ] Visual sanity check on mobile / md / lg breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)