### PR TITLE
Add Invidis Strategy Award 2026 and mark DSS Europe panels as past

### DIFF
--- a/assets/css/_about.scss
+++ b/assets/css/_about.scss
@@ -342,6 +342,12 @@
   border: 1px solid rgba(239, 93, 202, 0.3);
 }
 
+.event-pill-award {
+  color: #ffd700;
+  background: rgba(255, 215, 0, 0.12);
+  border: 1px solid rgba(255, 215, 0, 0.3);
+}
+
 .event-pill-upcoming {
   color: #fff;
   background: #22c55e;

--- a/assets/css/deferred.scss
+++ b/assets/css/deferred.scss
@@ -40,6 +40,10 @@
   border: 1px solid #5dbeef;
 }
 
+.event-award {
+  border: 1px solid #ffd700;
+}
+
 .event-upcoming {
   border-radius: rem(32px);
   font-family: $font-body;

--- a/data/events.yaml
+++ b/data/events.yaml
@@ -1,6 +1,9 @@
 ---
 - year: 2026
   events:
+    - type: award
+      event: Invidis Strategy Award 2026
+      title: "Winner in the category Business Critical / Cybersecurity for Screenly"
     - type: talk
       event: FOSDEM
       location: Brussels, Belgium
@@ -37,19 +40,16 @@
       location: Munich, Germany
       title: "Cybersecurity in Digital Signage - Unpatched, Unsecured, Unprotected"
       link: https://digitalsignagesummit.org/newfront/sessions/1897
-      upcoming: true
     - type: panel
       event: Digital Signage Summit Europe
       location: Munich, Germany
       title: "AI Spotlight"
       link: https://digitalsignagesummit.org/newfront/sessions/1894
-      upcoming: true
     - type: panel
       event: Digital Signage Summit Europe
       location: Munich, Germany
       title: "Security Reality Check: 90% of Signage Software Is Not Secure"
       link: https://digitalsignagesummit.org/newfront/sessions/2016
-      upcoming: true
 
 - year: 2025
   events:


### PR DESCRIPTION
## Summary
- Add new `award` event type with the Invidis Strategy Award 2026 win (Business Critical / Cybersecurity category for Screenly) to the 2026 events
- Remove `upcoming: true` from the three DSS Europe 2026 panels now that the event has passed
- Add gold-toned pill and border styles for the new `award` type in `_about.scss` and `deferred.scss`

## Test plan
- [ ] `hugo serve` and verify the 2026 events list shows the new award entry with a gold pill
- [ ] Verify the three DSS Europe panels no longer show the "Upcoming" badge
- [ ] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)