### PR TITLE
Add InfoQ press entry and link Invidis award

### DIFF
--- a/data/events.yaml
+++ b/data/events.yaml
@@ -4,6 +4,7 @@
     - type: award
       event: Invidis Strategy Award 2026
       title: "Winner in the category Business Critical / Cybersecurity for Screenly"
+      link: https://invidis.com/news/2026/05/invidis-strategy-awards-2026-the-winners-of-2026/
     - type: talk
       event: FOSDEM
       location: Brussels, Belgium
@@ -35,6 +36,10 @@
       publication: RedMonk
       title: "AI Slop & the Vulnerability Treadmill"
       link: https://redmonk.com/kholterhoff/2026/05/05/ai-slop-vulnerability-treadmill/
+    - type: press
+      publication: InfoQ
+      title: "Leading Open Source Author Calls for Verification over Trust in Software Supply Chains"
+      link: https://www.infoq.com/news/2026/05/stenberg-curl-verification-trust/
     - type: panel
       event: Digital Signage Summit Europe
       location: Munich, Germany


### PR DESCRIPTION
## Summary
- Add InfoQ press entry "Leading Open Source Author Calls for Verification over Trust in Software Supply Chains" to 2026 press section
- Link Invidis Strategy Award 2026 entry to the winners announcement

## Test plan
- [ ] Verify both entries render correctly on the events/press section

🤖 Generated with [Claude Code](https://claude.com/claude-code)