### PR TITLE
Exclude generated llms files from lychee in deploy workflow too

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -68,7 +68,11 @@ jobs:
       - name: Check internal links with lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --offline --root-dir ${{ github.workspace }}/public ${{ github.workspace }}/public
+          # llms.txt and llms-full.txt are excluded: they contain raw Markdown
+          # (including quoted emails and URL-like strings in old posts) that
+          # lychee scans as plaintext; every real link in them also exists in
+          # the HTML pages.
+          args: --no-progress --offline --root-dir ${{ github.workspace }}/public --exclude-path '${{ github.workspace }}/public/llms.txt' --exclude-path '${{ github.workspace }}/public/llms-full.txt' ${{ github.workspace }}/public
           fail: true
 
       - name: Upload Artifact


### PR DESCRIPTION
## Summary

#101 excluded the generated `llms.txt` / `llms-full.txt` from the lychee link check in `lint.yml`, but missed that `build-deploy.yml` has its own identical lychee step. That step [failed on master](https://github.com/vpetersson/vpetersson.com/actions/runs/29194981782/job/86656241181) after the merge: `llms-full.txt` ships raw Markdown from legacy posts containing quoted email addresses and a `vnc://127.0.0.1:0"` example string that lychee mis-parses as links when scanning plaintext.

This applies the same `--exclude-path` exclusion (and comment) to the deploy workflow. Every real link in these files also exists in the HTML pages, which are still fully checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)